### PR TITLE
docs(Serverless2): update README with port 8080 configuration for Railway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
 # Serverless2
+
+Serverless2 Project - Python Web Application
+This project, Serverless2, is a basic web application developed with Python and Flask, designed to demonstrate a simple "Hello World" functionality. It has been deployed on Railway for easy access.
+
+📋 Project Overview
+Serverless2 is a simple web application that responds with a "Hello World" message. It is designed for beginners to learn how to set up and deploy a Python web application using Flask. This project is ideal for understanding how to deploy applications on a serverless platform like Railway.
+
+🛠 Requirements
+To deploy this project on Railway, you’ll need:
+
+A GitHub account with your project files stored in a repository.
+A Railway account. You can sign up at Railway.app.
+The project files: app.py, requirements.txt, and Procfile.
+📂 Project Structure
+plaintext
+Copiar código
+Serverless2/
+├── app.py            # Main application file for Flask
+├── requirements.txt  # Specifies project dependencies
+└── Procfile          # Defines the start command for Railway
+app.py: Contains the Flask application code with a simple route that displays "Hello World". The code also reads the port from the environment variable PORT which Railway assigns automatically.
+requirements.txt: Lists all the Python dependencies needed for the application to run.
+Procfile: Specifies the command Railway should use to start the application.
+🚀 Step-by-Step Deployment on Railway
+Follow these steps to deploy Serverless2 on Railway.
+
+Step 1: Set Up the Project in GitHub
+Create a GitHub Repository: If you haven’t already, create a repository on GitHub for Serverless2.
+Upload Project Files: Ensure that app.py, requirements.txt, and Procfile are in the root directory of the repository.
+Commit Changes: Commit and push these files to the main branch on GitHub.
+Step 2: Set Up a Railway Account and Connect GitHub
+Sign Up/In to Railway: Go to Railway.app and log in or create an account.
+Connect GitHub: In Railway’s dashboard, link your GitHub account. This will allow Railway to access your repositories for deployment.
+Step 3: Deploy the Project on Railway
+Create a New Project:
+
+On the Railway dashboard, click on New Project.
+Select Deploy from GitHub repo to deploy from an existing GitHub repository.
+Select the Repository:
+
+Choose the Serverless2 repository from the list.
+Railway will detect that it’s a Python project and install the dependencies listed in requirements.txt.
+Configuring the Port to 8080:
+
+Go to the Settings tab in Railway and scroll to the Networking section.
+Under Public Networking, click Generate Domain.
+If prompted, enter 8080 as the target port for the application.
+Railway will then generate a URL for your application.
+Generate a Public Domain:
+
+In the Settings tab under Networking, click Generate Domain to create a public URL for your application.
+Step 4: Access the Application
+Open the Generated URL:
+Railway will provide a URL like https://serverless2-production.up.railway.app. Copy and open this URL in a browser to view the application.
+Verify the Functionality:
+You should see the message "Hello World from Python on Railway!" displayed on the page.
+🔄 Summary of Commands for GitHub
+For quick reference, here are the basic Git commands to upload your project to GitHub.
+
+bash
+Copiar código
+# Initialize a new Git repository (if needed)
+git init
+
+# Add all project files
+git add .
+
+# Commit the changes
+git commit -m "Initial commit of Serverless2 project"
+
+# Push to GitHub (replace 'main' if your branch name is different)
+git push origin main
+💡 Troubleshooting Tips
+If you encounter issues while deploying, here are some things to check:
+
+Root Directory: Ensure that app.py, requirements.txt, and Procfile are in the root directory of your repository.
+Public Networking: Verify that you generated a domain under Public Networking in Railway’s Settings.
+Dependency Compatibility: Ensure requirements.txt specifies compatible versions, especially for Flask and Werkzeug.
+Port Configuration: Make sure that app.py reads the PORT environment variable provided by Railway to avoid port conflicts and that you specify port 8080 when generating the domain if prompted.
+📜 License
+This project is open-source and available under the MIT License.


### PR DESCRIPTION
This PR updates the README for the Serverless2 project to include:

- Detailed instructions for configuring port 8080 when deploying to Railway.
- Additional guidance on the `Public Networking` setup for generating a domain.

These updates ensure that users can configure the port correctly for a smooth deployment experience on Railway.
